### PR TITLE
Add several wallet APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ hex = "0.4.2"
 reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls"] }
 serde = "1.0"
 serde_json = "1.0"
-testcontainers = "0.9"
+testcontainers = "0.10"
 thiserror = "1.0"
 tokio = { version = "0.2", default-features = false, features = ["blocking", "macros", "rt-core", "time"] }
 tracing = "0.1"

--- a/src/bitcoind_rpc.rs
+++ b/src/bitcoind_rpc.rs
@@ -37,6 +37,19 @@ impl Client {
         Ok(blockchain_info.mediantime)
     }
 
+    pub async fn block_height(&self) -> Result<u32> {
+        let block_height = self
+            .rpc_client
+            .send::<Vec<()>, _>(json_rpc::Request::new(
+                "getblockcount",
+                vec![],
+                JSONRPC_VERSION.into(),
+            ))
+            .await?;
+
+        Ok(block_height)
+    }
+
     async fn blockchain_info(&self) -> Result<BlockchainInfo> {
         let blockchain_info = self
             .rpc_client

--- a/src/bitcoind_rpc.rs
+++ b/src/bitcoind_rpc.rs
@@ -222,6 +222,26 @@ impl Client {
         Ok(transaction)
     }
 
+    pub async fn get_transaction(
+        &self,
+        wallet_name: &str,
+        txid: Txid,
+    ) -> Result<WalletTransactionInfo> {
+        let res = self
+            .rpc_client
+            .send_with_path(
+                format!("/wallet/{}", wallet_name),
+                json_rpc::Request::new(
+                    "gettransaction",
+                    vec![json_rpc::serialize(txid)?],
+                    JSONRPC_VERSION.into(),
+                ),
+            )
+            .await?;
+
+        Ok(res)
+    }
+
     pub async fn dump_wallet(&self, wallet_name: &str, filename: &std::path::Path) -> Result<()> {
         let _: DumpWalletResponse = self
             .rpc_client
@@ -580,6 +600,16 @@ pub struct AddressInfo {
     #[serde(rename = "hdmasterfingerprint")]
     pub hd_master_fingerprint: String,
     pub labels: Vec<String>,
+}
+
+/// Response to the RPC command `gettransaction`.
+///
+/// It only defines one field, but can be expanded to include all the
+/// fields returned by `bitcoind` (see:
+/// https://bitcoincore.org/en/doc/0.19.0/rpc/wallet/gettransaction/)
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
+pub struct WalletTransactionInfo {
+    pub fee: f64,
 }
 
 #[cfg(all(test, feature = "test-docker"))]

--- a/src/bitcoind_rpc.rs
+++ b/src/bitcoind_rpc.rs
@@ -7,6 +7,7 @@ use ::bitcoin::{
 };
 use bitcoin::{consensus::encode, Script};
 use reqwest::Url;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -217,22 +218,37 @@ impl Client {
         Ok(txid)
     }
 
-    pub async fn get_raw_transaction(&self, wallet_name: &str, txid: Txid) -> Result<Transaction> {
-        let hex: String = self
-            .rpc_client
-            .send_with_path(
-                format!("/wallet/{}", wallet_name),
-                json_rpc::Request::new(
-                    "getrawtransaction",
-                    vec![json_rpc::serialize(txid)?],
-                    JSONRPC_VERSION.into(),
-                ),
-            )
-            .await?;
+    pub async fn get_raw_transaction(&self, txid: Txid) -> Result<Transaction> {
+        let hex: String = self.get_raw_transaction_rpc(txid, false).await?;
         let bytes: Vec<u8> = FromHex::from_hex(&hex)?;
         let transaction = bitcoin::consensus::encode::deserialize(&bytes)?;
 
         Ok(transaction)
+    }
+
+    pub async fn get_raw_transaction_verbose(
+        &self,
+        txid: Txid,
+    ) -> Result<GetRawTransactionVerboseResponse> {
+        let res = self.get_raw_transaction_rpc(txid, true).await?;
+
+        Ok(res)
+    }
+
+    async fn get_raw_transaction_rpc<R>(&self, txid: Txid, is_verbose: bool) -> Result<R>
+    where
+        R: std::fmt::Debug + DeserializeOwned,
+    {
+        let res = self
+            .rpc_client
+            .send(json_rpc::Request::new(
+                "getrawtransaction",
+                vec![json_rpc::serialize(txid)?, json_rpc::serialize(is_verbose)?],
+                JSONRPC_VERSION.into(),
+            ))
+            .await?;
+
+        Ok(res)
     }
 
     pub async fn get_transaction(
@@ -454,6 +470,18 @@ impl Client {
             .await?;
         Ok(address_info)
     }
+
+    pub async fn get_block(&self, block_hash: &bitcoin::BlockHash) -> Result<GetBlockResponse> {
+        let res = self
+            .rpc_client
+            .send(json_rpc::Request::new(
+                "getblock",
+                vec![json_rpc::serialize(block_hash)?],
+                JSONRPC_VERSION.into(),
+            ))
+            .await?;
+        Ok(res)
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -623,6 +651,28 @@ pub struct AddressInfo {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
 pub struct WalletTransactionInfo {
     pub fee: f64,
+}
+
+/// Response to the RPC command `getrawtransaction`, when the second
+/// argument is set to `true`.
+///
+/// It only defines one field, but can be expanded to include all the
+/// fields returned by `bitcoind` (see:
+/// https://bitcoincore.org/en/doc/0.19.0/rpc/rawtransactions/getrawtransaction/)
+#[derive(Clone, Copy, Debug, Deserialize)]
+pub struct GetRawTransactionVerboseResponse {
+    #[serde(rename = "blockhash")]
+    pub block_hash: Option<bitcoin::BlockHash>,
+}
+
+/// Response to the RPC command `getblock`.
+///
+/// It only defines one field, but can be expanded to include all the
+/// fields returned by `bitcoind` (see:
+/// https://bitcoincore.org/en/doc/0.19.0/rpc/blockchain/getblock/)
+#[derive(Copy, Clone, Debug, Deserialize)]
+pub struct GetBlockResponse {
+    pub height: u32,
 }
 
 #[cfg(all(test, feature = "test-docker"))]

--- a/src/json_rpc.rs
+++ b/src/json_rpc.rs
@@ -43,7 +43,6 @@ impl Client {
             .await?;
 
         let response = response.bytes().await?;
-        dbg!(&response);
 
         let response: Response<Res> = match serde_json::from_slice(&response) {
             Ok(response) => response,

--- a/src/json_rpc.rs
+++ b/src/json_rpc.rs
@@ -43,6 +43,7 @@ impl Client {
             .await?;
 
         let response = response.bytes().await?;
+        dbg!(&response);
 
         let response: Response<Res> = match serde_json::from_slice(&response) {
             Ok(response) => response,


### PR DESCRIPTION
Commits should be reviewable separately.

These are used in `comit-network/xmr-btc-swap`.