### PR TITLE
Access client from wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+-   **Breaking Change**: Use `bitcoincore_rpc_json::GetRawTransactionVerboseResponse` as return type for `get_raw_transaction_verbose` to get all fields.
 -   Expose bitcoind rpc client from wallet.
 
 ## [0.1.0] - 2020-11-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   Expose bitcoind rpc client from wallet.
+
 ## [0.1.0] - 2020-11-11
 
 ### Added

--- a/src/bitcoind_rpc.rs
+++ b/src/bitcoind_rpc.rs
@@ -229,7 +229,7 @@ impl Client {
     pub async fn get_raw_transaction_verbose(
         &self,
         txid: Txid,
-    ) -> Result<GetRawTransactionVerboseResponse> {
+    ) -> Result<bitcoincore_rpc_json::GetRawTransactionResult> {
         let res = self.get_raw_transaction_rpc(txid, true).await?;
 
         Ok(res)
@@ -651,18 +651,6 @@ pub struct AddressInfo {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
 pub struct WalletTransactionInfo {
     pub fee: f64,
-}
-
-/// Response to the RPC command `getrawtransaction`, when the second
-/// argument is set to `true`.
-///
-/// It only defines one field, but can be expanded to include all the
-/// fields returned by `bitcoind` (see:
-/// https://bitcoincore.org/en/doc/0.19.0/rpc/rawtransactions/getrawtransaction/)
-#[derive(Clone, Copy, Debug, Deserialize)]
-pub struct GetRawTransactionVerboseResponse {
-    #[serde(rename = "blockhash")]
-    pub block_hash: Option<bitcoin::BlockHash>,
 }
 
 /// Response to the RPC command `getblock`.

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -112,7 +112,7 @@ impl Wallet {
     pub async fn transaction_block_height(&self, txid: Txid) -> Result<Option<u32>> {
         let res = self.client.get_raw_transaction_verbose(txid).await?;
 
-        let block_hash = match res.block_hash {
+        let block_hash = match res.blockhash {
             Some(block_hash) => block_hash,
             None => return Ok(None),
         };


### PR DESCRIPTION
-   **Breaking Change**: Use `bitcoincore_rpc_json::GetRawTransactionVerboseResponse` as return type for `get_raw_transaction_verbose` to get all fields.
-   Expose bitcoind rpc client from wallet.