### PR TITLE
Export jsonrpc_client

### DIFF
--- a/src/bitcoind_rpc.rs
+++ b/src/bitcoind_rpc.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 use std::collections::HashMap;
 
 pub use crate::bitcoind_rpc_api::*;
+pub use jsonrpc_client;
 
 pub type Result<T> = std::result::Result<T, Error>;
 


### PR DESCRIPTION
Initially I had only the `JsonRpcError` exposed, but it seems to be discouraged to re-export only parts of a 3rd party library so I am now re-exporting the whole crate `jsonrpc_client`.