### PR TITLE
Cleanup dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,12 @@ serde = "1.0"
 serde_json = "1.0"
 testcontainers = "0.11"
 thiserror = "1.0"
-tokio = { version = "1.0", default-features = false, features = ["rt-multi-thread", "macros", "time"] }
+tokio = { version = "1.0", features = ["time"] }
 tracing = "0.1"
 url = "2"
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ bitcoincore-rpc-json = "0.13"
 futures = "0.3.5"
 hex = "0.4.2"
 jsonrpc_client = { version = "0.5", features = ["reqwest"] }
-reqwest = { version = "0.11", default-features = false, features = ["json", "native-tls"] }
+reqwest = { version = "0.11", default-features = false, features = ["json"] }
 serde = "1.0"
 serde_json = "1.0"
 testcontainers = "0.11"


### PR DESCRIPTION
Please have a look at this.

The way cargo's features work causes a rippling effect which can completely take away control from downstream users.
For this particular case, unnecessarily activating `native-tls` causes a dependency on `openssl` having to be installed for `asb` and `swap-cli` without a way of deactivating that downstream because the feature set is **additive** across the whole dependency graph.

As such, it is really important to always edit manifest files consciously. I made such an [error](https://github.com/thomaseizinger/rust-jsonrpc-client/pull/21) myself in the `jsonrpc-client` which is quite annoying because I have to cut another release now that could have been avoided :)