### PR TITLE
Bump up testcontainers to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ jsonrpc_client = { version = "0.5", features = ["reqwest"] }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 serde = "1.0"
 serde_json = "1.0"
-testcontainers = "0.11"
+testcontainers = "0.12"
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["time"] }
 tracing = "0.1"


### PR DESCRIPTION
I have been making the GUI for xmr-btc-swap as discussed [here ](https://github.com/comit-network/xmr-btc-swap/discussions/654) and have been getting troubles compiling for testing while using Tauri.

Bumping up the dependency solves this problem and gets it up to date with the testcontainers dependency in xmr-btc-swap