### PR TITLE
deps: upgrade bitcoin, bitcoincore-rpc-json, jsonrpc_client, and testcontainers 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,18 +7,16 @@ description = "A simple lib to start a bitcoind container, generate blocks and f
 license = "MIT"
 
 [dependencies]
-# Hopefully goes away: https://github.com/thomaseizinger/rust-jsonrpc-client/issues/6
-async-trait = "0.1"
 base64 = "0.12.3"
-bitcoin = { version = "0.27", features = ["use-serde"] }
-bitcoincore-rpc-json = "0.14"
+bitcoin = { version = "0.28", features = ["use-serde"] }
+bitcoincore-rpc-json = "0.15"
 futures = "0.3.5"
 hex = "0.4.2"
-jsonrpc_client = { version = "0.5", features = ["reqwest"] }
+jsonrpc_client = { version = "0.7", features = ["reqwest"] }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 serde = "1.0"
 serde_json = "1.0"
-testcontainers = "0.11"
+testcontainers = "0.14"
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["time"] }
 tracing = "0.1"

--- a/src/bitcoind_rpc.rs
+++ b/src/bitcoind_rpc.rs
@@ -103,13 +103,13 @@ impl Client {
         Ok(res)
     }
 
-    async fn get_raw_transaction_rpc<R>(&self, txid: Txid, is_verbose: bool) -> Result<R>
+    async fn get_raw_transaction_rpc<R>(&self, txid: Txid, verbose: bool) -> Result<R>
     where
         R: std::fmt::Debug + DeserializeOwned,
     {
         let body = jsonrpc_client::Request::new_v2("getrawtransaction")
-            .with_argument(txid)?
-            .with_argument(is_verbose)?
+            .with_argument("txid".into(), txid)?
+            .with_argument("verbose".into(), verbose)?
             .serialize()?;
 
         let payload: ResponsePayload<R> = self
@@ -236,7 +236,7 @@ mod test {
     async fn get_network_info() {
         let tc_client = clients::Cli::default();
         let (client, _container) = {
-            let blockchain = Bitcoind::new(&tc_client, "0.19.1").unwrap();
+            let blockchain = Bitcoind::new(&tc_client).unwrap();
 
             (Client::new(blockchain.node_url.clone()), blockchain)
         };
@@ -250,7 +250,7 @@ mod test {
     async fn get_median_time() {
         let tc_client = clients::Cli::default();
         let (client, _container) = {
-            let blockchain = Bitcoind::new(&tc_client, "0.19.1").unwrap();
+            let blockchain = Bitcoind::new(&tc_client).unwrap();
 
             (Client::new(blockchain.node_url.clone()), blockchain)
         };
@@ -261,7 +261,7 @@ mod test {
     #[tokio::test]
     async fn blockcount() {
         let tc_client = testcontainers::clients::Cli::default();
-        let bitcoind = Bitcoind::new(&tc_client, "0.19.1").unwrap();
+        let bitcoind = Bitcoind::new(&tc_client).unwrap();
         bitcoind.init(5).await.unwrap();
 
         let client = Client::new(bitcoind.node_url.clone());

--- a/src/bitcoind_rpc.rs
+++ b/src/bitcoind_rpc.rs
@@ -196,12 +196,6 @@ pub enum Error {
     ParseUrl(#[from] url::ParseError),
 }
 
-#[derive(Debug, Deserialize)]
-struct BlockchainInfo {
-    chain: Network,
-    mediantime: u32,
-}
-
 /// Response to the RPC command `getrawtransaction`, when the second
 /// argument is set to `true`.
 ///

--- a/src/bitcoind_rpc_api.rs
+++ b/src/bitcoind_rpc_api.rs
@@ -78,7 +78,7 @@ pub trait BitcoindRpcApi {
     async fn walletprocesspsbt(&self, psbt: PsbtBase64) -> WalletProcessPsbtResponse;
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct DumpWalletResponse {
     pub filename: String,
 }

--- a/src/bitcoind_rpc_api.rs
+++ b/src/bitcoind_rpc_api.rs
@@ -24,25 +24,18 @@ pub trait BitcoindRpcApi {
 
     async fn finalizepsbt(&self, psbt: PsbtBase64) -> FinalizePsbtResult;
 
-    async fn generatetoaddress(
-        &self,
-        nblocks: u32,
-        address: Address,
-        max_tries: Option<u32>,
-    ) -> Vec<BlockHash>;
+    async fn generatetoaddress(&self, nblocks: u32, address: Address) -> Vec<BlockHash>;
 
     async fn getaddressinfo(&self, address: &Address) -> GetAddressInfoResult;
 
-    // TODO: Manual implementation to avoid odd "account" parameter
     async fn getbalance(
         &self,
-        account: Account,
-        minimum_confirmation: Option<u32>,
-        include_watch_only: Option<bool>,
+        minconf: Option<u32>,
+        include_watchonly: Option<bool>,
         avoid_reuse: Option<bool>,
     ) -> f64;
 
-    async fn getblock(&self, block_hash: &bitcoin::BlockHash) -> GetBlockResult;
+    async fn getblock(&self, blockhash: &bitcoin::BlockHash) -> GetBlockResult;
 
     async fn getblockchaininfo(&self) -> GetBlockchainInfoResult;
 
@@ -56,19 +49,19 @@ pub trait BitcoindRpcApi {
 
     async fn getwalletinfo(&self) -> GetWalletInfoResult;
 
-    async fn joinpsbts(&self, psbts: &[String]) -> PsbtBase64;
+    async fn joinpsbts(&self, txs: &[String]) -> PsbtBase64;
 
     async fn listunspent(
         &self,
-        min_conf: Option<u32>,
-        max_conf: Option<u32>,
+        minconf: Option<u32>,
+        maxconf: Option<u32>,
         addresses: Option<Vec<Address>>,
         include_unsafe: Option<bool>,
     ) -> Vec<ListUnspentResultEntry>;
 
     async fn listwallets(&self) -> Vec<String>;
 
-    async fn sendrawtransaction(&self, transaction: TransactionHex) -> String;
+    async fn sendrawtransaction(&self, hexstring: TransactionHex) -> String;
 
     /// amount is btc
     async fn sendtoaddress(&self, address: Address, amount: f64) -> String;

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,5 +1,5 @@
 use crate::bitcoind_rpc::{Client, Result};
-use crate::bitcoind_rpc_api::{Account, BitcoindRpcApi, PsbtBase64, WalletProcessPsbtResponse};
+use crate::bitcoind_rpc_api::{BitcoindRpcApi, PsbtBase64, WalletProcessPsbtResponse};
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::{Address, Amount, Transaction, Txid};
 use bitcoincore_rpc_json::{
@@ -73,7 +73,7 @@ impl Wallet {
         let response = self
             .client
             .with_wallet(&self.name)?
-            .getbalance(Account, None, None, None)
+            .getbalance(None, None, None)
             .await?;
         let amount = Amount::from_btc(response)?;
         Ok(amount)
@@ -173,7 +173,7 @@ mod test {
     #[tokio::test]
     async fn get_wallet_transaction() {
         let tc_client = testcontainers::clients::Cli::default();
-        let bitcoind = Bitcoind::new(&tc_client, "0.19.1").unwrap();
+        let bitcoind = Bitcoind::new(&tc_client).unwrap();
         bitcoind.init(5).await.unwrap();
 
         let wallet = Wallet::new("wallet", bitcoind.node_url.clone())
@@ -196,7 +196,7 @@ mod test {
     #[tokio::test]
     async fn two_party_psbt_test() {
         let tc_client = testcontainers::clients::Cli::default();
-        let bitcoind = Bitcoind::new(&tc_client, "0.19.1").unwrap();
+        let bitcoind = Bitcoind::new(&tc_client).unwrap();
         bitcoind.init(5).await.unwrap();
 
         let alice = Wallet::new("alice", bitcoind.node_url.clone())
@@ -284,7 +284,7 @@ mod test {
     #[tokio::test]
     async fn transaction_block_height() {
         let tc_client = testcontainers::clients::Cli::default();
-        let bitcoind = Bitcoind::new(&tc_client, "0.19.1").unwrap();
+        let bitcoind = Bitcoind::new(&tc_client).unwrap();
         bitcoind.init(5).await.unwrap();
 
         let wallet = Wallet::new("wallet", bitcoind.node_url.clone())

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -48,7 +48,7 @@ impl Wallet {
     }
 
     pub async fn median_time(&self) -> Result<u64> {
-        Ok(self.client.median_time().await?)
+        self.client.median_time().await
     }
 
     #[deprecated(


### PR DESCRIPTION
Hey! 

I'm working on a bunch of dependency upgrades xmr-btc-swap, which includes comit-network/xmr-btc-swap#1107 

BDK 0.21 uses Bitcoin 0.28, so following the yak shave landed me here :) 

- bitcoin 0.28
- bitcoincore-rpc-json 0.15
- jsonrpc_client 0.7
- testcontainers 0.14